### PR TITLE
Emit a ready event when instance is loaded

### DIFF
--- a/src/vue-ckeditor.js
+++ b/src/vue-ckeditor.js
@@ -79,6 +79,7 @@ export default {
           .create(this.$el, this.config)
           .then(editor => {
             this.instance = editor
+            this.$emit('ready', editor)
 
             const instance = this.instance
             instance.isReadOnly = this.readonly


### PR DESCRIPTION
This is required when adding any post-instance hooks. e.g. uploadAdapter, that has added in such a manner:
```js
editor.plugins.get( 'FileRepository' ).createUploadAdapter = function( loader ) {
    return new UploadAdapter(loader)
}
```
For this, when integrating vue-ckeditor, the developer has to know when the instance is ready.