### PR TITLE
Pass through unused attributes to ckeditor element

### DIFF
--- a/src/vue-ckeditor.js
+++ b/src/vue-ckeditor.js
@@ -1,7 +1,11 @@
 export default {
   name: 'vue-ckeditor',
 
-  render: createElement => createElement('div'),
+  render(createElement) {
+    return createElement('div', {
+      attrs: this.$attrs
+    })
+  },
 
   props: {
     config: {


### PR DESCRIPTION
Some ckeditor plugins pull from attributes on the element that is
being replaced.

Think something like placeholder. This PR allows for using ckeditor like
```
<ckeditor type="classic" placeholder="Put some text here"></ckeditor>
```
and having a Plugin that pull the placeholder from the source element.