### PR TITLE
Allow configuration of empty value.

### DIFF
--- a/src/vue-ckeditor.js
+++ b/src/vue-ckeditor.js
@@ -90,7 +90,7 @@ export default {
     },
     isEmpty() {
       const document = this.instance.model.document
-      return document.model.hasContent(document.getRoot())
+      return !document.model.hasContent(document.getRoot())
     },
   },
 

--- a/src/vue-ckeditor.js
+++ b/src/vue-ckeditor.js
@@ -59,6 +59,9 @@ export default {
       default: () => '',
       required: false,
       type: String
+    },
+    emptyValue: {
+      default: '',
     }
   },
 
@@ -79,6 +82,16 @@ export default {
         instance.setData(newValue)
       }
     }
+  },
+
+  computed: {
+    emptyValueProvided() {
+      return 'emptyValue' in this.$options.propsData
+    },
+    isEmpty() {
+      const document = this.instance.model.document
+      return document.model.hasContent(document.getRoot())
+    },
   },
 
   methods: {
@@ -162,9 +175,12 @@ export default {
 
       if (instance != null) {
         instance.model.document.on('change:data', (...args) => {
-          const newValue = instance.getData()
+          let newValue = instance.getData()
 
           if (this.value !== newValue) {
+            if (this.emptyValueProvided && this.isEmpty) {
+              newValue = this.emptyValue
+            }
             this.$emit('input', newValue, instance, ...args)
           }
         })


### PR DESCRIPTION
ckeditor5's "value" for an empty text field is `<p>&nbsp;</p>`. It would be nice to be able to configure what an empty value is so application code does not need to check for content meaning no content.

`emptyValue` property is not typed to allow for any value to
represent "empty" (null, false, empty string, other).

`isEmpty` strategy was taken from [ckeditor emptyness](https://github.com/alexeckermann/ckeditor5-emptyness/blob/master/src/emptyness.js#L45).